### PR TITLE
Added GENERIC-SEQ-ITER:ON-SEQ driver. Added destructing

### DIFF
--- a/src/generic-seq-iter-pkg.lisp
+++ b/src/generic-seq-iter-pkg.lisp
@@ -6,4 +6,5 @@
 (defpackage :generic-seq-iter
   (:use :cl :generic-seq :iter)
   (:nicknames #:gen-seq-iter)
-  (:export #:in-seq))
+  (:export #:in-seq
+	   #:on-seq))

--- a/src/generic-seq-iter.lisp
+++ b/src/generic-seq-iter.lisp
@@ -5,21 +5,39 @@
 
 (in-package :generic-seq-iter)
 
-(defmacro-driver (FOR var IN-SEQ seq)
-  "All items of the sequence."
-  (let ((enum (gensym "ENUM"))
-        (enum-defined (gensym "ENUM-DEFINED"))
-        (enum-cdr (gensym "ENUM-CDR"))
-        (kwd (if generate 'generate 'for)))
-    `(progn
-       (with ,enum-defined = nil)
-       (generate ,enum next (let ((,enum-cdr 
-                                   (if ,enum-defined
-                                       (enum-cdr ,enum)
-                                     (progn
-                                       (setf ,enum-defined t)
-                                       (seq-enum ,seq)))))
-                              (if ,enum-cdr 
-                                  ,enum-cdr 
-                                (terminate))))
-       (,kwd ,var next (enum-car (next ,enum))))))
+(defmacro define-generic-seq-iter-driver (name next-enum-operation traverse-init-value)
+`(defmacro-driver (FOR var ,NAME seq)
+   (let ((enum (gensym "ENUM"))
+	 (enum-defined (gensym "ENUM-DEFINED"))
+	 (enum-cdr (gensym "ENUM-CDR"))
+	 (next-enum (gensym "NEXT-ENUM"))
+	 (kwd (if generate 'generate 'for)))
+     (labels ((traverse (var enum &optional enum-defined)
+		(when var
+		  (if (listp var)
+		      (append (traverse (car var)
+					(if enum-defined
+					  `(enum-car ,enum)
+					  `(enum-car (seq-enum ,enum))))
+			      (traverse (cdr var)
+					(if enum-defined
+					  `(enum-cdr ,enum)
+					  `(enum-cdr (seq-enum ,enum)))
+					t))
+		      `((for ,var next ,enum))))))
+       `(progn
+	  (with ,enum-defined = nil)
+	  (generate ,enum next (let ((,enum-cdr 
+				       (if ,enum-defined
+					   (enum-cdr ,enum)
+					   (progn
+					     (setf ,enum-defined t)
+					     (seq-enum ,seq)))))
+				 (if ,enum-cdr 
+				     ,enum-cdr 
+				     (terminate))))
+	  (,kwd ,next-enum next (,',next-enum-operation (next ,enum)))
+	,@(traverse var next-enum ,traverse-init-value))))))
+
+(define-generic-seq-iter-driver IN-SEQ enum-car nil)
+(define-generic-seq-iter-driver ON-SEQ identity t)

--- a/src/generic-seq.lisp
+++ b/src/generic-seq.lisp
@@ -37,7 +37,10 @@
 
 (defmacro enum-cdr (enum)
   "Return the CDR part."
-  `(funcall (cdr ,enum)))
+  (let ((enum-cdr (gensym "ENUM-CDR")))
+   `(let ((,enum-cdr (cdr ,enum)))
+      (when ,enum-cdr
+	(funcall ,enum-cdr)))))
 
 (defun enum-append-2 (enum-1 delayed-enum-2)
   "Append two enumerators."
@@ -659,11 +662,12 @@ return this element; otherwise NIL is returned."
 
 (defmethod seq-enum ((seq list))
   (labels ((traverse (list)
-             (if (null list)
-                 nil
-               (enum-cons
-                (car list)
-                (traverse (cdr list))))))
+             (when list
+	       (if (consp list)
+		   (enum-cons
+		    (car list)
+		    (traverse (cdr list)))
+		   list))))
     (traverse seq)))
 
 ;;;

--- a/test/generic-seq-test.lisp
+++ b/test/generic-seq-test.lisp
@@ -225,12 +225,42 @@
     (seq->list (seq-interpose :a '(1 2 3 4)))
   (1 :a 2 :a 3 :a 4))
 
-(deftest test-in-seq
-    (seq->list
-     (iter (for n from 1 to 5)
-           (for x in-seq (seq-range))
-           (collect x)))
+(deftest test-in-seq-1
+    (iter (for n from 1 to 5)
+          (for x in-seq (seq-range))
+          (collect x))
   (0 1 2 3 4))
+
+(deftest test-in-seq-2
+    (iter (for (a (b (c)) d) in-seq '((1 (2 (3)) 4) #(5 #(6 #(7)) 8)))
+          (collect (list a b c d)))
+  ((1 2 3 4) (5 6 7 8)))
+
+(deftest test-in-seq-3
+    (iter (for (a b (c) d) in-seq '((1 2) #(3 4)))
+          (collect (list a b c d)))
+  ((1 2 nil nil) (3 4 nil nil)))
+
+(deftest test-in-seq-4
+    (iter (for (a b) in-seq (list (seq-range) (seq-range :start 10) (seq-range :start 20)))
+          (collect (list a b)))
+  ((0 1) (10 11) (20 21)))
+
+(deftest test-on-seq-1
+    (iter (for (a b) on-seq '(1 2 3))
+          (collect (list a b)))
+  ((1 2) (2 3) (3 nil)))
+
+(deftest test-on-seq-2
+    (iter (for (a b) on-seq (seq-range))
+          (for i from 0 to 4)
+          (collect (list a b)))
+  ((0 1) (1 2) (2 3) (3 4) (4 5)))
+
+(deftest test-on-seq-3
+    (iter (for ((i) (j)) on-seq (list (seq-range) (seq-range :start 10)))
+          (collect (list i j)))
+  ((0 10) (10 nil)))
 
 (deftest test-with-seq/cc
     (seq->list


### PR DESCRIPTION
Добавлен ON-SEQ  драйвер.

Теперь можно писать:

``` lisp
CL-USER> (iter (for (a b . c) on-seq (seq-range))
               (for i from 0 to 4)
               (print (list a b c)))

(0 1 (2 . #<CLOSURE # {100471F38B}>)) 
(1 2 (3 . #<CLOSURE # {100472834B}>)) 
(2 3 (4 . #<CLOSURE # {10047292FB}>)) 
(3 4 (5 . #<CLOSURE # {100472A2AB}>)) 
(4 5 (6 . #<CLOSURE # {100472B25B}>)) 
NIL
```

Добавлен destructing для драйверов IN-SEQ и ON-SEQ. Можно в тестах примеры посмотреть.

В связи с destructing пришлось сделать несколько изменений:

1) enum-cdr теперь проверяет на nil свой аргумент. Если тот nil возвращает nil, а не выбрасывает исключение. Нужно в различных случаях, например:

``` lisp
CL-USER> (iter (for (a b c) on-seq '(1 2 3))
           (print (list a b c)))

(1 2 3) 
(2 3 NIL) 
(3 NIL NIL) 
NIL
```

иначе не заработает.

2) изменил seq-enum для списка, теперь (enum-cdr (enum-cdr '(1 . 2))) вернет nil, а не исключение. Нужно и в iter, и в многих других местах где используется cons. Например, flatten должен выравнивать и cons.  Без этого изменения flatten у меня не получалось написать.

Я не стал добавлять слово BY в драйверы т.к. есть seq-take-nth.
